### PR TITLE
enhance FHIR structure definitions with additional mustSupport fields

### DIFF
--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboranforderung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboranforderung.json
@@ -378,6 +378,23 @@
         "mustSupport": true
       },
       {
+        "id": "ServiceRequest.category.coding.system",
+        "path": "ServiceRequest.category.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.category.coding.code",
+        "path": "ServiceRequest.category.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.category.coding.display",
+        "path": "ServiceRequest.category.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "ServiceRequest.category.coding:laboratory",
         "path": "ServiceRequest.category.coding",
         "sliceName": "laboratory",
@@ -436,8 +453,40 @@
         }
       },
       {
+        "id": "ServiceRequest.code.coding",
+        "path": "ServiceRequest.code.coding",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.code.coding.system",
+        "path": "ServiceRequest.code.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.code.coding.code",
+        "path": "ServiceRequest.code.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.code.coding.display",
+        "path": "ServiceRequest.code.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "ServiceRequest.subject",
         "path": "ServiceRequest.subject",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.subject.reference",
+        "path": "ServiceRequest.subject.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.subject.identifier",
+        "path": "ServiceRequest.subject.identifier",
         "mustSupport": true
       },
       {
@@ -479,6 +528,16 @@
             }
           ]
         },
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.encounter.reference",
+        "path": "ServiceRequest.encounter.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.encounter.identifier",
+        "path": "ServiceRequest.encounter.identifier",
         "mustSupport": true
       },
       {

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laborbefund.json
@@ -278,6 +278,16 @@
         "mustSupport": true
       },
       {
+        "id": "DiagnosticReport.basedOn.reference",
+        "path": "DiagnosticReport.basedOn.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.basedOn.identifier",
+        "path": "DiagnosticReport.basedOn.identifier",
+        "mustSupport": true
+      },
+      {
         "id": "DiagnosticReport.status",
         "path": "DiagnosticReport.status",
         "short": "Status",
@@ -377,6 +387,23 @@
         "mustSupport": true
       },
       {
+        "id": "DiagnosticReport.category.coding.system",
+        "path": "DiagnosticReport.category.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.category.coding.code",
+        "path": "DiagnosticReport.category.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.category.coding.display",
+        "path": "DiagnosticReport.category.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "DiagnosticReport.category.coding:loinc-lab",
         "path": "DiagnosticReport.category.coding",
         "sliceName": "loinc-lab",
@@ -457,6 +484,23 @@
         "mustSupport": true
       },
       {
+        "id": "DiagnosticReport.code.coding.system",
+        "path": "DiagnosticReport.code.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.code.coding.code",
+        "path": "DiagnosticReport.code.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.code.coding.display",
+        "path": "DiagnosticReport.code.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "DiagnosticReport.code.coding:loinc-labReport",
         "path": "DiagnosticReport.code.coding",
         "sliceName": "loinc-labReport",
@@ -472,6 +516,16 @@
         "id": "DiagnosticReport.subject",
         "path": "DiagnosticReport.subject",
         "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.subject.reference",
+        "path": "DiagnosticReport.subject.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.subject.identifier",
+        "path": "DiagnosticReport.subject.identifier",
         "mustSupport": true
       },
       {
@@ -513,6 +567,16 @@
             }
           ]
         },
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.encounter.reference",
+        "path": "DiagnosticReport.encounter.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.encounter.identifier",
+        "path": "DiagnosticReport.encounter.identifier",
         "mustSupport": true
       },
       {
@@ -762,6 +826,11 @@
           ]
         },
         "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "DiagnosticReport.result.reference",
+        "path": "DiagnosticReport.result.reference",
         "mustSupport": true
       },
       {

--- a/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-labor-laboruntersuchung.json
@@ -351,6 +351,23 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.category.coding.system",
+        "path": "Observation.category.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.category.coding.code",
+        "path": "Observation.category.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.category.coding.display",
+        "path": "Observation.category.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "Observation.category.coding:loinc-observation",
         "path": "Observation.category.coding",
         "sliceName": "loinc-observation",
@@ -421,9 +438,41 @@
         }
       },
       {
+        "id": "Observation.code.coding",
+        "path": "Observation.code.coding",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.code.coding.system",
+        "path": "Observation.code.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.code.coding.code",
+        "path": "Observation.code.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.code.coding.display",
+        "path": "Observation.code.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "Observation.subject",
         "path": "Observation.subject",
         "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.subject.reference",
+        "path": "Observation.subject.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.subject.identifier",
+        "path": "Observation.subject.identifier",
         "mustSupport": true
       },
       {
@@ -465,6 +514,16 @@
             }
           ]
         },
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.encounter.reference",
+        "path": "Observation.encounter.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.encounter.identifier",
+        "path": "Observation.encounter.identifier",
         "mustSupport": true
       },
       {
@@ -700,6 +759,10 @@
           {
             "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
             "valueCode": "draft"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
+            "valueCode": "4.0.0"
           }
         ],
         "path": "Observation.value[x].extension",
@@ -727,6 +790,10 @@
           {
             "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
             "valueCode": "draft"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
+            "valueCode": "4.0.0"
           }
         ],
         "path": "Observation.value[x].value.extension",
@@ -990,6 +1057,28 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.method.coding",
+        "path": "Observation.method.coding",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.method.coding.system",
+        "path": "Observation.method.coding.system",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.method.coding.code",
+        "path": "Observation.method.coding.code",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.method.coding.display",
+        "path": "Observation.method.coding.display",
+        "mustSupport": true
+      },
+      {
         "id": "Observation.specimen",
         "path": "Observation.specimen",
         "short": "Probenmaterial",
@@ -1082,6 +1171,16 @@
         "mustSupport": true
       },
       {
+        "id": "Observation.device.reference",
+        "path": "Observation.device.reference",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.device.identifier",
+        "path": "Observation.device.identifier",
+        "mustSupport": true
+      },
+      {
         "id": "Observation.referenceRange",
         "path": "Observation.referenceRange",
         "short": "Referenzbereich",
@@ -1120,6 +1219,16 @@
             }
           ]
         },
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.referenceRange.low",
+        "path": "Observation.referenceRange.low",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.referenceRange.high",
+        "path": "Observation.referenceRange.high",
         "mustSupport": true
       }
     ]

--- a/input/fsh/profiles/MII_PR_Labor_Laboranforderung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboranforderung.fsh
@@ -39,7 +39,6 @@ Description: "Dieses Profil beschreibt eine Laboranforderung in der Medizininfor
 * identifier[anforderung].system 1.. MS
 * identifier[anforderung].value 1.. MS
 * identifier[anforderung].assigner 1.. MS
-//* identifier[anforderung].assigner only $MII-Reference
 * status = #completed (exactly)
 * status MS
   * ^short = "Status"
@@ -58,6 +57,9 @@ Description: "Dieses Profil beschreibt eine Laboranforderung in der Medizininfor
 * insert Translation(category ^short, en-US, Category)
 * insert Translation(category ^definition, en-US, Classification as laboratory order)
 * category.coding MS
+  * system 1.. MS
+  * code 1.. MS
+  * display MS
 * category.coding ^slicing.discriminator.type = #pattern
 * category.coding ^slicing.discriminator.path = "$this"
 * category.coding ^slicing.rules = #open
@@ -69,11 +71,18 @@ Description: "Dieses Profil beschreibt eine Laboranforderung in der Medizininfor
 * insert Translation(code ^short, en-US, Code)
 * insert Translation(code ^definition, en-US, A LOINC code identifying the laboratory test that was ordered.)
 * code from mii-vs-labor-order-codes (example)
+  * coding MS
+    * system 1.. MS
+    * code 1.. MS
+    * display MS
 * subject 1.. MS
-//* subject only $MII-Reference
+  * reference MS
+  * identifier MS
 * encounter MS
   * ^short = "Fall oder Kontakt"
   * ^definition = "Fall oder Kontakt, bei dem der Laborauftrag gestellt wurde."
+  * reference MS
+  * identifier MS
 * insert Translation(encounter ^short, en-US, Encounter)
 * insert Translation(encounter ^definition, en-US, Encounter during which the laboratory order was placed.)
 * authoredOn 1.. MS
@@ -84,9 +93,9 @@ Description: "Dieses Profil beschreibt eine Laboranforderung in der Medizininfor
 * specimen MS
   * ^short = "Probenmaterial"
   * ^definition = "Eine oder mehrere Bioproben, die der Labortest verwendet."
+  * reference MS
+  * identifier MS
 * insert Translation(specimen ^short, en-US, Specimen)
 * insert Translation(specimen ^definition, en-US, One or more specimens that are used by the laboratory test.)
-* specimen.reference MS
-* specimen.identifier MS
 * bodySite ..0
 * patientInstruction ..0

--- a/input/fsh/profiles/MII_PR_Labor_Laborbefund.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laborbefund.fsh
@@ -40,10 +40,11 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * identifier[befund].system 1.. MS
 * identifier[befund].value 1.. MS
 * identifier[befund].assigner 1.. MS
-//* identifier[befund].assigner only $MII-Reference
 * basedOn 1.. MS
   * ^short = "Basiert auf"
   * ^definition = "Bezug zum Laborauftrag, auf dem dieser Laborbefund basiert."
+  * reference MS
+  * identifier MS
 * insert Translation(basedOn ^short, en-US, Based on)
 * insert Translation(basedOn ^definition, en-US, Reference to the laboratory order on which this laboratory report is based.)
 //* basedOn only $MII-Reference
@@ -58,6 +59,9 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * insert Translation(category ^short, en-US, Category)
 * insert Translation(category ^definition, en-US, Classification of the report as laboratory report)
 * category.coding MS
+  * system 1.. MS
+  * code 1.. MS
+  * display MS
 * category.coding ^slicing.discriminator.type = #pattern
 * category.coding ^slicing.discriminator.path = "$this"
 * category.coding ^slicing.rules = #open
@@ -69,19 +73,25 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * code MS
   * ^short = "Code"
   * ^definition = "LOINC Code zur Identifikation des Befunds als Laborbefund."
+  * coding MS
+    * system 1.. MS
+    * code 1.. MS
+    * display MS
 * insert Translation(code ^short, en-US, Code)
 * insert Translation(code ^definition, en-US, A LOINC code identifying the report as laboratory report.)
-* code.coding MS
 * code.coding ^slicing.discriminator.type = #pattern
 * code.coding ^slicing.discriminator.path = "$this"
 * code.coding ^slicing.rules = #open
 * code.coding contains loinc-labReport 1..1 MS
 * code.coding[loinc-labReport] = $loinc#11502-2
 * subject 1.. MS
-//* subject only $MII-Reference
+  * reference MS
+  * identifier MS
 * encounter MS
   * ^short = "Fall oder Kontakt"
   * ^definition = "Fall oder Kontakt, bei dem der Laborbefund erstellt wurde."
+  * reference MS
+  * identifier MS
 * insert Translation(encounter ^short, en-US, Encounter)
 * insert Translation(encounter ^definition, en-US, Encounter during which the laboratory report was created.)
 * effective[x] 1.. MS
@@ -105,20 +115,21 @@ Description: "Dieses Profil beschreibt einen Laborbefund in der Medizininformati
 * performer MS
   * ^short = "Ausführende*r"
   * ^definition = "Verantwortliche Person oder Organisation, die für die Ausstellung des Befunds verantwortlich ist."
+  * reference MS
+  * identifier MS
 * insert Translation(performer ^short, en-US, Performer)
 * insert Translation(performer ^definition, en-US, The diagnostic service that is responsible for issuing the report.)
-* performer.reference MS
-* performer.identifier MS
 * specimen MS
   * ^short = "Probenmaterial"
   * ^definition = "Bioproben, auf denen dieser Laborbefund basiert."
+  * reference MS
+  * identifier MS
 * insert Translation(specimen ^short, en-US, Specimen)
 * insert Translation(specimen ^definition, en-US, Details about the specimens on which this diagnostic report is based.)
-* specimen.reference MS
-* specimen.identifier MS
 * result 1.. MS
   * ^short = "Ergebnis"
   * ^definition = "Laborergebnisse, die Teil dieses Laborbefunds sind."
+  * reference MS
 * insert Translation(result ^short, en-US, Result)
 * insert Translation(result ^definition, en-US, Laboratory test results that are part of this diagnostic report.)
 //* result only $MII-Reference

--- a/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
+++ b/input/fsh/profiles/MII_PR_Labor_Laboruntersuchung.fsh
@@ -41,7 +41,6 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * identifier[analyseBefundCode].system 1.. MS
 * identifier[analyseBefundCode].value 1.. MS
 * identifier[analyseBefundCode].assigner 1.. MS
-//* identifier[analyseBefundCode].assigner only $MII-Reference
 * status MS
   * ^short = "Status"
   * ^definition = "abgeschlossen"
@@ -52,7 +51,11 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
   * ^definition = "Klassifikation in diagnostischen Fachbereich und Gruppe der Laboruntersuchung"
 * insert Translation(category ^short, en-US, Category)
 * insert Translation(category ^definition, en-US, Classification of the laboratory test in the diagnostic service section and laboratory group)
-* category.coding MS
+* category
+  * coding MS
+    * system 1.. MS
+    * code 1.. MS
+    * display MS
 * category.coding ^slicing.discriminator.type = #pattern
 * category.coding ^slicing.discriminator.path = "$this"
 * category.coding ^slicing.rules = #open
@@ -64,15 +67,22 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * code MS
   * ^short = "Code"
   * ^definition = "Ein LOINC Code für den Laborparameter bzw. Labortest, der durchgeführt wurde."
+  * coding MS
+    * system 1.. MS
+    * code 1.. MS
+    * display MS
 * insert Translation(code ^short, en-US, Code)
 * insert Translation(code ^definition, en-US, A LOINC code identifying the laboratory test that was performed.)
 * code from $ResultsLabObservationUvIps (preferred)
 * code ^binding.description = "Intensional Value Set Definition: LOINC {  {    STATUS in {ACTIVE}    CLASSTYPE in {1}    CLASS exclude {CHALSKIN, H&P.HX.LAB, H&P.HX, NR STATS, PATH.PROTOCOLS.*}  } }"
 * subject 1.. MS
-//* subject only $MII-Reference
+  * reference MS
+  * identifier MS
 * encounter MS
   * ^short = "Fall oder Kontakt"
   * ^definition = "Fall oder Kontakt, bei dem die Laboruntersuchung durchgeführt wurde."
+  * reference MS
+  * identifier MS
 * insert Translation(encounter ^short, en-US, Encounter)
 * insert Translation(encounter ^definition, en-US, Encounter during which the laboratory test was performed.)
 * effective[x] 1.. MS
@@ -137,22 +147,30 @@ Description: "Dieses Profil beschreibt eine Laborergebnis in der Medizininformat
 * method MS
   * ^short = "Untersuchungsmethode"
   * ^definition = "Konkrete Untersuchungsmethode, wenn der verwendete LOINC-Code für den Laborparameter keine Methode enthält."
+  * coding MS
+    * system 1.. MS
+    * code 1.. MS
+    * display MS
 * insert Translation(method ^short, en-US, Method)
 * insert Translation(method ^definition, en-US, Specific examination method\, if the LOINC code for the laboratory test does not contain a method)
 * specimen MS
   * ^short = "Probenmaterial"
   * ^definition = "Probe, auf deren Basis die Laboruntersuchungen angefertigt werden"
+  * reference MS
+  * identifier MS
 * insert Translation(specimen ^short, en-US, Specimen)
 * insert Translation(specimen ^definition, en-US, Specimen on which the laboratory tests are performed)
-* specimen.reference MS
-* specimen.identifier MS
 * device MS
   * ^short = "Gerät"
   * ^definition = "Gerät, das zur Generierung der Messwerte verwendet wurde."
+  * reference MS
+  * identifier MS
 * insert Translation(device ^short, en-US, Device)
 * insert Translation(device ^definition, en-US, The device used to generate the test data.)
 * referenceRange MS
   * ^short = "Referenzbereich"
   * ^definition = "Bereich, in dem der Messwert als normal oder empfohlen betrachtet wird."
+  * low MS
+  * high MS
 * insert Translation(referenceRange ^short, en-US, Reference range)
 * insert Translation(referenceRange ^definition, en-US, Guidance on how to interpret the value by comparison to a normal or recommended range.)


### PR DESCRIPTION
fixes #31

This pull request extends the FHIR profiles for laboratory orders (`Laboranforderung`), laboratory reports (`Laborbefund`), and laboratory observations (`Laboruntersuchung`) to add more granular Must Support (MS) constraints and minimum cardinalities on key elements, especially for identifiers, references, and codings. These changes improve interoperability and ensure that required data elements are consistently present in implementations.

**Key changes by theme:**

### Enhanced Must Support and Cardinality for Coding Elements
* Added `system`, `code`, and `display` as Must Support (and in many cases, with `min: 1`) for `category.coding` and `code.coding` elements in `ServiceRequest`, `DiagnosticReport`, and `Observation` profiles. This ensures that codings are always well-defined and interoperable. [[1]](diffhunk://#diff-b56a72882e08253e9aeaf78e907846ef69dd08635815e1e3c3d524467b5bdc87R380-R396) [[2]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R389-R405) [[3]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R486-R502) [[4]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR353-R369) [[5]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR440-R477) [[6]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR1059-R1080)

### Improved Reference and Identifier Requirements
* Marked `reference` and `identifier` subfields as Must Support for `subject`, `encounter`, `specimen`, `basedOn`, `performer`, `device`, and `result` where appropriate, across all three profiles. This makes it easier to reliably link resources and trace provenance. [[1]](diffhunk://#diff-b56a72882e08253e9aeaf78e907846ef69dd08635815e1e3c3d524467b5bdc87R455-R491) [[2]](diffhunk://#diff-b56a72882e08253e9aeaf78e907846ef69dd08635815e1e3c3d524467b5bdc87R533-R542) [[3]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R280-R289) [[4]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R521-R530) [[5]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R572-R581) [[6]](diffhunk://#diff-34f5d0c1de418461c964121d916a3ed2809154c23f15a7f5fc1ca3b3b07c7669R831-R835) [[7]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR440-R477) [[8]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR519-R528) [[9]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR1173-R1182)

### Reference Range and Method Details for Observations
* Added Must Support for `Observation.referenceRange.low` and `Observation.referenceRange.high`, as well as for all subfields of `Observation.method.coding`, ensuring that method and reference range information are always available when present. [[1]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR1059-R1080) [[2]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR1223-R1232)

### FSH Profile Alignment and Clean-up
* Updated FSH profile definitions to align with the JSON StructureDefinitions, ensuring that Must Support flags and cardinalities are consistent and removing redundant or commented-out constraints. [[1]](diffhunk://#diff-78cdeed523a98833bd0ae5635c01edf5195402d22d3aae586e5920a118582ea6L42) [[2]](diffhunk://#diff-78cdeed523a98833bd0ae5635c01edf5195402d22d3aae586e5920a118582ea6R60-R62) [[3]](diffhunk://#diff-78cdeed523a98833bd0ae5635c01edf5195402d22d3aae586e5920a118582ea6R74-R85) [[4]](diffhunk://#diff-78cdeed523a98833bd0ae5635c01edf5195402d22d3aae586e5920a118582ea6R96-L90) [[5]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966L43-R47) [[6]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966R62-R64) [[7]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966R76-R94) [[8]](diffhunk://#diff-3f20380d323d4f578bff92685dcc63870cf670de8ef07a19b634b522794e5966R118-R132)

### FHIR Version Metadata
* Added the normative FHIR version extension (`structuredefinition-normative-version: 4.0.0`) to relevant Observation value extensions for better metadata tracking. [[1]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR762-R765) [[2]](diffhunk://#diff-a88bf71ffafc927b251859577d18506539b9d575f4f856d19d4abf65fe6a5a0cR793-R796)